### PR TITLE
Update to ensure scoop facts are only loaded when scoop class is defined

### DIFF
--- a/lib/facter/scoop.rb
+++ b/lib/facter/scoop.rb
@@ -9,9 +9,10 @@ end
 
 Facter.add('scoop') do
   confine osfamily: :windows
+  confine do 
+    defined? (basedir)
+  end
   setcode do
-    confine { basedir }
-
     regkey_path = 'System\CurrentControlSet\Control\Session Manager\Environment'
     basedir = nil
     Win32::Registry::HKEY_LOCAL_MACHINE.open(regkey_path) do |regkey|


### PR DESCRIPTION
We were getting the below error for all Windows systems that were not configured to use `scoop`

```text
error while resolving custom fact "scoop": The system cannot find the file specified.

Source:	Facter
```

Moved the confine up to outer block solved the issue.  Confine statements need to be on the outside of blocks not within the block itself